### PR TITLE
url 정규 표현식 적용

### DIFF
--- a/controller/ContextMenuController.py
+++ b/controller/ContextMenuController.py
@@ -23,6 +23,8 @@ class ContextMenuController(IBurpExtender, IContextMenuFactory):
                 req_url = req.getUrl().toString()
             except:
                 req_url = req.getHeaders()[0].split(" ")[1]
+            
+            req_url = self.packet_manager.parseUrl(req_url)
 
             menu_name = "Add comments about this url"
             menu_item = JMenuItem(menu_name, actionPerformed = self.comment_url_popup_service.onClickContextMenu)

--- a/service/url/PacketManager.py
+++ b/service/url/PacketManager.py
@@ -1,3 +1,6 @@
+from urlparse import urlparse
+import re
+
 import dto.PacketInfo as PacketInfo
 
 class PacketManager():
@@ -5,6 +8,7 @@ class PacketManager():
     def __init__(self, config):
         self.info = PacketInfo.PacketInfo()
         self.info.info = config.readPacketInfo()
+        self.URL_REGEX = "\/[0-9]+\/*"
     
     def getPacketInfo(self, url):
         return self.info.getInfo(url)
@@ -29,3 +33,14 @@ class PacketManager():
                 message.setComment(comment)
             except:
                 pass
+        
+    def parseUrl(self, url):
+        path = urlparse(url).path
+        match_list = re.compile(self.URL_REGEX).findall(path)
+
+        if len(match_list) != 0:
+            for d in match_list:
+                d = d.replace("/", "")
+                path = path.replace(d, "{{%d}}")
+        
+        return path


### PR DESCRIPTION
고정적인 URL에 comment 를 작성할 경우, 다음과 같은 상황에서는 다른 행위의 URL로 인식되는 문제점이 있다.

```
/api/user/info/123
/api/user/info/222
```

IDOR 같은 형식의 URL 일 경우, 같은 URL로 인식을 하기 위해 정규표현식을 이용하여 다음과 같이 변경하였다.

```
/api/user/info/{{%d}}
/api/user/info/{{%d}}
```

결론적으로, 숫자만 치환하여 같은 역할을 하는 URL에 다른 URL 이어도 같은 comment를 삽입하게 된다.